### PR TITLE
Fixes to klab generation

### DIFF
--- a/examples/SafeAdd/config.json
+++ b/examples/SafeAdd/config.json
@@ -7,7 +7,7 @@
       "tests/specs/mcd/verification.k"
     ],
     "imports": [
-      "VERIFICATION",
+      "LEMMAS-MCD"
     ],
     "concrete-rules": [
       "EDSL.#ceil32",

--- a/examples/SafeAdd/config.json
+++ b/examples/SafeAdd/config.json
@@ -2,11 +2,12 @@
   "src": {
     "specification": "src/specification.act.md",
     "lemmas": "src/verification.k",
+    "rules": [],
     "requires": [
-      {
-        "file": "tests/specs/mcd/verification.k",
-        "module": "VERIFICATION"
-      }
+      "tests/specs/mcd/verification.k"
+    ],
+    "imports": [
+      "VERIFICATION",
     ],
     "concrete-rules": [
       "EDSL.#ceil32",

--- a/lib/build.js
+++ b/lib/build.js
@@ -16,7 +16,8 @@ const {
   getStatus
 }                   = require("./util.js")
 const {
-  collisionCheck
+  collisionCheck,
+  getStorageDef
 } = require("./storage.js");
 const KLAB_OUT      = process.env.KLAB_OUT || "out";
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -12,6 +12,13 @@ const {
 const KLAB_OUT      = process.env.KLAB_OUT || "out";
 const config_json   = JSON.parse(read("./config.json"));
 const config        = Config(config_json);
+const rule_paths    = config.src.rules;
+const raw_rules     = rule_paths.map(p => read(p)).join("\n\n")
+const rules         = marked
+  .lexer(raw_rules)
+  .filter(block => block.type === "code")
+  .map(block => block.text)
+  .join("\n\n")
 
 // returns the storage def object
 // Array of "lines"
@@ -56,6 +63,17 @@ const getBlock = block => {
     doc
   }
 }
+
+const storage_def = rules
+  .split(/\n(\ \t)*\n/)
+  .filter(block => block !== undefined)
+  .filter(block => /^(\s*\/\/[^\n]*\n)*syntax/.test(block))
+  .map(block => block.split("\n"))
+  .reduce((a, block) => {
+    return a.concat(getBlock(block));
+  }, [])
+const getStorageDef = str => storage_def.find(def => def.test(str))
+
 
 const collisionCheck = act => {
     if (act.storage) {
@@ -106,5 +124,6 @@ const collisionCheck = act => {
 }
 
 module.exports = {
-    collisionCheck
+    collisionCheck,
+    getStorageDef
 }

--- a/libexec/klab-make
+++ b/libexec/klab-make
@@ -204,13 +204,13 @@ output_makefile.push('')
 output_makefile.push('$(KLAB_OUT)/specs/verification.k: ' + config_json['src']['lemmas'] + ' $(KLAB_OUT)/specs/bin_runtime.k')
 output_makefile.push('\techo > $@')
 for (i in config_json['src']['requires']) {
-  req_file = config_json['src']['requires'][i]['file']
+  req_file = config_json['src']['requires'][i]
   output_makefile.push('\techo \'requires "' + req_file + '"\' >> $@')
 }
 output_makefile.push('\techo >> $@')
 output_makefile.push('\techo \'module KLAB-VERIFICATION\' >> $@')
-for (i in config_json['src']['requires']) {
-  req_import = config_json['src']['requires'][i]['module']
+for (i in config_json['src']['imports']) {
+  req_import = config_json['src']['imports'][i]
   output_makefile.push('\techo \'    imports ' + req_import + '\' >> $@')
 }
 output_makefile.push('\techo >> $@')


### PR DESCRIPTION
-  Bring back `getStorageDef`, which is needed for k-dss.
-  Separate out `imports` and `requires` section of `config.json` so that you can have many files included, and many imports into the `KLAB-VERIFICATION` module.