### PR TITLE
Allow using global install of KEVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ Set the `KLAB_OUT` directory to where you would like all proof artifacts to be s
 ### Setting up KEVM
 
 KLab no longer handles setting up KEVM for you.
-Follow the [Instructions for KEVM](https://github.com/kframework/evm-semantics) to setup KEVM, in particular you need to build the Java backend (`make build-java`).
-Make sure that you setup the environment variable `KLAB_EVMS_PATH` to point to the absolute path of the KEVM repository root.
+Install KEVM following the [release instructions](https://github.com/kframework/evm-semantics/releases).
+
+If you build KEVM from source, make sure you set the environment variable `KLAB_EVMS_PATH` to point to the root of the KEVM repository.
 
 ### Available klab Commands
 

--- a/examples/SafeAdd/config.json
+++ b/examples/SafeAdd/config.json
@@ -4,7 +4,7 @@
     "lemmas": "src/verification.k",
     "rules": [],
     "requires": [
-      "tests/specs/mcd/verification.k"
+      "lemmas/mcd/verification.k"
     ],
     "imports": [
       "LEMMAS-MCD"

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -15,7 +15,7 @@ const prune_edges = (proofid, { prune, verbose } = {}) => {
   // console.log(`pruning ${proofid}`);
 
   if(verbose) console.log("read the log...");
-  const logs = read(path.join(KLAB_WD_PATH, proofid + ".log"))
+  const logs = read(path.join(KLAB_WD_PATH, proofid + ".k.log"))
     .split("\n")
     .filter(l => !!l)
   // .map(l => l.split(" "))
@@ -99,8 +99,8 @@ const prune_edges = (proofid, { prune, verbose } = {}) => {
     .map(l => l.split(" ")[2].split("_")[0])
     .reduce((a, ruleid) => {
       if(a && !a[ruleid]) {
-        try { a[ruleid] = JSON.parse(read(path.join(KLAB_WD_PATH, `${proofid}_blobs`, ruleid + ".json"))) }
-        catch(e) {console.log('bad json: ' + path.join(KLAB_WD_PATH, `${proofid}_blobs`, ruleid + ".json"))}
+        try { a[ruleid] = JSON.parse(read(path.join(KLAB_WD_PATH, `${proofid}.k_blobs`, ruleid + ".json"))) }
+        catch(e) {console.log('bad json: ' + path.join(KLAB_WD_PATH, `${proofid}.k_blobs`, ruleid + ".json"))}
       }
       return a;
     }, {})

--- a/lib/driver/dbDriver.js
+++ b/lib/driver/dbDriver.js
@@ -20,7 +20,7 @@ if (!testPath(KLAB_WD_PATH)) fs.mkdirSync(KLAB_WD_PATH);
 
 const getBlob = (proofid, blobid, cb) => {
   // const wd_path = path.join(KLAB_WD_PATH, proofid + "/")
-  fs.readFile(path.join(KLAB_WD_PATH, `/${proofid}_blobs/${blobid}.json`), (error, content) => {
+  fs.readFile(path.join(KLAB_WD_PATH, `/${proofid}.k_blobs/${blobid}.json`), (error, content) => {
     let json={};
     try {
       json = JSON.parse(content)

--- a/libexec/klab-check-sublemmas
+++ b/libexec/klab-check-sublemmas
@@ -16,8 +16,8 @@ echo "$count_trusted_rules"
 [[ "$count_trusted_rules" != 0 ]] || exit 0
 
 find_rules() {
-    for rule in $(grep 'SRULE' out/data/$proof_hash.log | cut --delimiter=' ' --field=3 | cut --delimiter='_' --field=1); do
-        cat "out/data/${proof_hash}_blobs/$rule.json"                       \
+    for rule in $(grep 'SRULE' out/data/$proof_hash.k.log | cut --delimiter=' ' --field=3 | cut --delimiter='_' --field=1); do
+        cat "out/data/${proof_hash}.k_blobs/$rule.json"                     \
             | jq .term.att                                                  \
             | grep --only-matching "label($proof_hash_upper.[A-Za-z.]*)"    \
             | cut --delimiter='(' --field=2 | cut --delimiter=')' --field=1 \

--- a/libexec/klab-debug
+++ b/libexec/klab-debug
@@ -132,7 +132,7 @@ if(targett) {
 constraint_blobs.concat(key_terms).concat(targett.split("_")[0])
   .forEach((blobid, i) => {
     console.log(i);
-    const json = JSON.parse(read(path.join(KLAB_WD_PATH, `${proofid}_blobs`, blobid + ".json"))).term;
+    const json = JSON.parse(read(path.join(KLAB_WD_PATH, `${proofid}.k_blobs`, blobid + ".json"))).term;
     blobs_data[blobid] = json;
   })
 }
@@ -141,15 +141,15 @@ console.log("reading rules: " + rule_blobs.length);
 const rules_data = rule_blobs
     .reduce((a, ruleid) => {
       if(a && !a[ruleid]) {
-        try { a[ruleid] = JSON.parse(read(path.join(KLAB_WD_PATH, `${proofid}_blobs`, ruleid + ".json"))) }
-        catch(e) {console.log('bad json: ' + path.join(KLAB_WD_PATH, `${proofid}_blobs`, ruleid + ".json"))}
+        try { a[ruleid] = JSON.parse(read(path.join(KLAB_WD_PATH, `${proofid}.k_blobs`, ruleid + ".json"))) }
+        catch(e) {console.log('bad json: ' + path.join(KLAB_WD_PATH, `${proofid}.k_blobs`, ruleid + ".json"))}
       }
       return a;
     }, {})
 
   //     .map(blobid => {
   //       let jsonn;
-  //       try { jsonn = JSON.parse(read(path.join(KLAB_WD_PATH, `${proofid}_blobs`, blobid + ".json")))       } catch(e) { console.log('bad json: ' + path.join(KLAB_WD_PATH, `${proofid}_blobs`, blobid + ".json"))}
+  //       try { jsonn = JSON.parse(read(path.join(KLAB_WD_PATH, `${proofid}.k_blobs`, blobid + ".json")))       } catch(e) { console.log('bad json: ' + path.join(KLAB_WD_PATH, `${proofid}.k_blobs`, blobid + ".json"))}
   //       return [blobid, jsonn]})
   // .reduce((a, [id, json]) => ({...a, [id]: json.term}), {})
 

--- a/libexec/klab-get-refund
+++ b/libexec/klab-get-refund
@@ -25,12 +25,12 @@ const cmd = docopt(usage, {
 });
 const proofid = cmd['<hash>']
 
-if(!testPath(path.join(KLAB_OUT, "data", proofid + ".log"))) {
+if(!testPath(path.join(KLAB_OUT, "data", proofid + ".k.log"))) {
   console.error("klab-get-refund: no logfile for " + proofid);
   process.exit(1);
 }
 
-const logs = read(path.join(KLAB_WD_PATH, proofid + ".log"))
+const logs = read(path.join(KLAB_WD_PATH, proofid + ".k.log"))
   .split("\n")
   .filter(l => !!l)
 
@@ -42,14 +42,14 @@ const refund_rule = Object.keys(logs
     a[r] = true;
     return a;
   }, {}))
-      .find(r => JSON.parse(read(path.join(KLAB_WD_PATH, proofid + "_blobs", r + ".json"))).term.att.indexOf('refund') > - 1)
+      .find(r => JSON.parse(read(path.join(KLAB_WD_PATH, proofid + ".k_blobs", r + ".json"))).term.att.indexOf('refund') > - 1)
 
 const refund_nodes = logs
   .filter(l => l.split(" ")[1] == "RULE" && l.split(" ")[2].split("_")[0] == refund_rule)
   .map(l => l.split(" ")[2].split("_")[1])
 
 const refunds = refund_nodes
-  .map(id => JSON.parse(read(path.join(KLAB_WD_PATH, proofid + "_blobs", id + ".json"))))
+  .map(id => JSON.parse(read(path.join(KLAB_WD_PATH, proofid + ".k_blobs", id + ".json"))))
   .map(node => {
     const refund_gas = kast.get(node.term, "k").args[0].args[0]
     return refund_gas;

--- a/libexec/klab-get-x
+++ b/libexec/klab-get-x
@@ -26,7 +26,7 @@ const cmd = docopt(usage, {
 const kpath = cmd['<kpath>']
 const proofid = cmd['<hash>']
 
-if(!testPath(path.join(KLAB_OUT, "data", proofid + ".log"))) {
+if(!testPath(path.join(KLAB_OUT, "data", proofid + ".k.log"))) {
   console.error("klab-get-x: no logfile for " + proofid);
   process.exit(1);
 }
@@ -105,7 +105,7 @@ const minus = args => ({
 })
 
 
-const blob = blobid => JSON.parse(read(path.join(KLAB_WD_PATH, proofid + "_blobs", blobid + ".json")));
+const blob = blobid => JSON.parse(read(path.join(KLAB_WD_PATH, proofid + ".k_blobs", blobid + ".json")));
 
 
 const isMinus = (gasExpr) => gasExpr.label && gasExpr.label == '_-Int__INT-COMMON'

--- a/libexec/klab-make
+++ b/libexec/klab-make
@@ -18,7 +18,8 @@ const {
 
 const __a2n = act => act.subject + "_" + act.name;
 
-const KLAB_OUT = process.env.KLAB_OUT || "out";
+const KLAB_OUT       = process.env.KLAB_OUT       || "out";
+const KLAB_EVMS_PATH = process.env.KLAB_EVMS_PATH || "/";
 
 const usage = `
 Usage:
@@ -90,7 +91,10 @@ pass = []
 output_makefile.push('KLAB_OUT ?= ' + KLAB_OUT)
 output_makefile.push('export KLAB_OUT')
 output_makefile.push('')
-output_makefile.push('PYTHONPATH ?= $(KLAB_EVMS_PATH)/deps/k/k-distribution/target/release/k/lib/kframework')
+output_makefile.push('KLAB_EVMS_PATH ?= ' + KLAB_EVMS_PATH)
+output_makefile.push('export KLAB_EVMS_PATH')
+output_makefile.push('')
+output_makefile.push('PYTHONPATH ?= $(KLAB_EVMS_PATH)/.build/deps/k/k-distribution/target/release/k/lib/kframework:/usr/lib/kevm/kframework/lib/kframework')
 output_makefile.push('export PYTHONPATH')
 output_makefile.push('')
 output_makefile.push('KLAB             := klab')
@@ -204,7 +208,7 @@ output_makefile.push('')
 output_makefile.push('$(KLAB_OUT)/specs/verification.k: ' + config_json['src']['lemmas'] + ' $(KLAB_OUT)/specs/bin_runtime.k')
 output_makefile.push('\techo > $@')
 for (i in config_json['src']['requires']) {
-  req_file = config_json['src']['requires'][i]
+  req_file = config_json['src']['requires'][i].replace('{KLAB_EVMS_PATH}', KLAB_EVMS_PATH)
   output_makefile.push('\techo \'requires "' + req_file + '"\' >> $@')
 }
 output_makefile.push('\techo >> $@')

--- a/libexec/klab-prove
+++ b/libexec/klab-prove
@@ -31,6 +31,7 @@ if [ -z "$KLAB_EVMS_PATH" ]; then
     exit 1
 fi
 echo "Using evm-semantics from $KLAB_EVMS_PATH"
+export PATH=$KLAB_EVMS_PATH/.build/usr/bin:$PATH
 
 if [ -f "$KLAB_OUT/meta/name/$spec_name" ]; then
   spec_hash=$(cat "$KLAB_OUT/meta/name/$spec_name")

--- a/libexec/klab-prove
+++ b/libexec/klab-prove
@@ -50,10 +50,14 @@ fi
 
 target_spec=${target_spec:-"$KLAB_OUT/specs/${spec_hash}.k"}
 
-K_FLAGS=()
+K_FLAGS=(--z3-impl-timeout 300 --no-exc-wrap)
+K_FLAGS+=(--cache-func-optimized --format-failures)
+K_FLAGS+=(--boundary-cells k,pc)
+K_FLAGS+=(--z3-tactic "(or-else (using-params smt :random-seed 3) (using-params smt :random-seed 2) (using-params smt :random-seed 1))")
+
+prove_mode=prove
 if $dump; then
-  z3=",RULEATTEMPT,SRULEATTEMPT,IMPLICATION,Z3QUERY,Z3RESULT"
-  K_FLAGS+=(--state-log --state-log-path "$KLAB_OUT/data" --state-log-id "$spec_hash" --state-log-events "OPEN,REACHINIT,REACHTARGET,REACHPROVED,RULE,SRULE,NODE,CLOSE")
+  prove_mode=klab-prove
   dump_notice="(with ${yellow}state logging${reset})"
 fi
 
@@ -64,28 +68,8 @@ fi
 info="$(basename "$target_spec") [$spec_name] $dump_notice"
 mkdir -p "$KLAB_OUT/started" && echo "$result" > "$KLAB_OUT/started/$spec_hash"
 echo "${blue}Proof ${bold}STARTING${reset}: $info"
-set +e
-trap 'echo "Trapped SIGTERM in klab-prove" && kill $kprove_child' TERM
-trap 'echo "Trapped SIGINT in klab-prove"  && kill $kprove_child' INT
-"$KLAB_EVMS_PATH/deps/k/k-distribution/target/release/k/bin/kprove" \
-  "${K_FLAGS[@]}" \
-  --directory "$KLAB_EVMS_PATH/.build/defn/java/" \
-  --def-module KLAB-VERIFICATION \
-  --output-omit "<jumpDests> <program> <code> <previousGas> <touchedAccounts> <interimStates> <callStack> <callData> <block> <txOrder> <txPending> <messages> #mkCall________EVM #callWithCode_________EVM #create_____EVM #mkCreate_____EVM #newAddrCreate2 #finishCodeDeposit___EVM" \
-  --output-flatten "_Map_ #And" \
-  --z3-impl-timeout 300 --no-exc-wrap \
-  --cache-func-optimized --format-failures \
-  --no-alpha-renaming \
-  --no-sort-collections \
-  --output json \
-  --boundary-cells k,pc \
-  --z3-tactic "(or-else (using-params smt :random-seed 3) (using-params smt :random-seed 2) (using-params smt :random-seed 1))" \
-  "$@" \
-  "$target_spec" >"$STDOUT" 2>"$STDERR" & kprove_child=$!
-wait "$kprove_child"
-result=$?
-unset kprove_child
-set -e
+result=0
+kevm $prove_mode "$target_spec" KLAB-VERIFICATION "${K_FLAGS[@]}" "$@" >"$STDOUT" 2>"$STDERR" || result="$?"
 
 if [ $result -eq 0 ]; then
   mkdir -p "$KLAB_OUT/accept" && echo "$result" > "$KLAB_OUT/accept/$spec_hash"

--- a/libexec/klab-simplify-gas
+++ b/libexec/klab-simplify-gas
@@ -22,7 +22,17 @@ def debug(msg):
         print(msg)
         sys.stdout.flush()
 
-definition = pyk.readKastTerm(os.environ['KLAB_EVMS_PATH'] + '/.build/defn/java/driver-kompiled/compiled.json')
+def fatal(msg):
+    print(msg)
+    sys.stdout.flush()
+    sys.exit(1)
+
+if os.path.isfile(os.environ['KLAB_EVMS_PATH'] + '/.build/defn/java/driver-kompiled/compiled.json'):
+    definition = pyk.readKastTerm(os.environ['KLAB_EVMS_PATH'] + '/.build/defn/java/driver-kompiled/compiled.json')
+elif os.path.isfile('/usr/lib/kevm/java/driver-kompiled/compiled.json'):
+    definition = pyk.readKastTerm('/usr/lib/kevm/java/driver-kompiled/compiled.json')
+else:
+    fatal('Cannot find "compiled.json"')
 
 ite_label     = '#if_#then_#else_#fi_K-EQUAL-SYNTAX'
 inf_gas_label = 'infGas'

--- a/libexec/klab-simplify-gas
+++ b/libexec/klab-simplify-gas
@@ -4,9 +4,20 @@ import json
 import resource
 import sys
 import os
-import pyk
 
+if os.path.isfile(os.environ['KLAB_EVMS_PATH'] + '/.build/usr/lib/kevm/java/driver-kompiled/compiled.json'):
+    compiled_file = os.environ['KLAB_EVMS_PATH'] + '/.build/usr/lib/kevm/java/driver-kompiled/compiled.json'
+    sys.path.append(os.environ['KLAB_EVMS_PATH'] + '/.build/usr/lib/kevm/kframework/lib/kframework')
+elif os.path.isfile('/usr/lib/kevm/java/driver-kompiled/compiled.json'):
+    compiled_file = '/usr/lib/kevm/java/driver-kompiled/compiled.json'
+    sys.path.append('/usr/lib/kevm/kframework/lib/kframework')
+else:
+    fatal('Cannot find "compiled.json"')
+
+import pyk
 from pyk import KApply, KVariable, KToken
+
+definition = pyk.readKastTerm(compiled_file)
 
 sys.setrecursionlimit(1500000000)
 resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
@@ -26,13 +37,6 @@ def fatal(msg):
     print(msg)
     sys.stdout.flush()
     sys.exit(1)
-
-if os.path.isfile(os.environ['KLAB_EVMS_PATH'] + '/.build/defn/java/driver-kompiled/compiled.json'):
-    definition = pyk.readKastTerm(os.environ['KLAB_EVMS_PATH'] + '/.build/defn/java/driver-kompiled/compiled.json')
-elif os.path.isfile('/usr/lib/kevm/java/driver-kompiled/compiled.json'):
-    definition = pyk.readKastTerm('/usr/lib/kevm/java/driver-kompiled/compiled.json')
-else:
-    fatal('Cannot find "compiled.json"')
 
 ite_label     = '#if_#then_#else_#fi_K-EQUAL-SYNTAX'
 inf_gas_label = 'infGas'


### PR DESCRIPTION
This PR does:

-   Makes KLab work with a global install of KEVM.
-   Makes it clear that with a global install of KEVM, setting `KLAB_EVMS_PATH` is optional, but with a local one it's not.
-   Uses `kevm prove` instead of `kprove` directly.